### PR TITLE
feat(dropdown): add optional placement and respect bootstrap classes

### DIFF
--- a/src/dropdown/docs/demo.html
+++ b/src/dropdown/docs/demo.html
@@ -131,6 +131,129 @@
         </div>
       </div>
     </div>
+    <!-- Placement use case -->
+    <h4>Inline placement and positioning</h4>
+    <div class="btn-group dropup" uib-dropdown >
+      <button id="simple-btn-dropup" type="button" class="btn btn-primary" uib-dropdown-toggle ng-disabled="disabled">
+        Button dropup <span class="caret"></span>
+      </button>
+      <ul class="dropdown-menu" uib-dropdown-menu role="menu" aria-labelledby="simple-btn-dropup">
+        <li role="menuitem"><a href="#">Action</a></li>
+        <li role="menuitem"><a href="#">Another action</a></li>
+        <li role="menuitem"><a href="#">Something else here</a></li>
+        <li class="divider"></li>
+        <li role="menuitem"><a href="#">Separated link</a></li>
+      </ul>
+    </div>
+    <div class="btn-group" uib-dropdown >
+      <button id="simple-btn-menu-right" type="button" class="btn btn-primary" uib-dropdown-toggle ng-disabled="disabled">
+        Button dropdown-menu-right <span class="caret"></span>
+      </button>
+      <ul class="dropdown-menu dropdown-menu-right" uib-dropdown-menu role="menu" aria-labelledby="simple-btn-menu-right">
+        <li role="menuitem"><a href="#">Action</a></li>
+        <li role="menuitem"><a href="#">Another action</a></li>
+        <li role="menuitem"><a href="#">Something else here</a></li>
+        <li class="divider"></li>
+        <li role="menuitem"><a href="#">Separated link</a></li>
+      </ul>
+    </div>
+    <div class="btn-group" uib-dropdown  dropdown-placement="top-left">
+      <button id="simple-btn-top-left" type="button" class="btn btn-primary" uib-dropdown-toggle ng-disabled="disabled">
+        Button top-left <span class="caret"></span>
+      </button>
+      <ul class="dropdown-menu" uib-dropdown-menu role="menu" aria-labelledby="simple-btn-top-left">
+        <li role="menuitem"><a href="#">Action</a></li>
+        <li role="menuitem"><a href="#">Another action</a></li>
+        <li role="menuitem"><a href="#">Something else here</a></li>
+        <li class="divider"></li>
+        <li role="menuitem"><a href="#">Separated link</a></li>
+      </ul>
+    </div>
+    <div class="btn-group" uib-dropdown  dropdown-placement="bottom-right">
+      <button id="simple-btn-bottom-right" type="button" class="btn btn-primary" uib-dropdown-toggle ng-disabled="disabled">
+        Button bottom-right <span class="caret"></span>
+      </button>
+      <ul class="dropdown-menu" uib-dropdown-menu role="menu" aria-labelledby="simple-btn-bottom-right">
+        <li role="menuitem"><a href="#">Action</a></li>
+        <li role="menuitem"><a href="#">Another action</a></li>
+        <li role="menuitem"><a href="#">Something else here</a></li>
+        <li class="divider"></li>
+        <li role="menuitem"><a href="#">Separated link</a></li>
+      </ul>
+    </div>
+    <div class="btn-group" uib-dropdown  dropdown-placement="right-top">
+      <button id="simple-btn-right-top" type="button" class="btn btn-primary" uib-dropdown-toggle ng-disabled="disabled">
+        Button right-top <span class="caret"></span>
+      </button>
+      <ul class="dropdown-menu" uib-dropdown-menu role="menu" aria-labelledby="simple-btn-right-top">
+        <li role="menuitem"><a href="#">Action</a></li>
+        <li role="menuitem"><a href="#">Another action</a></li>
+        <li role="menuitem"><a href="#">Something else here</a></li>
+        <li class="divider"></li>
+        <li role="menuitem"><a href="#">Separated link</a></li>
+      </ul>
+    </div>
+    <h4>append-to-body placement and positioning</h4>
+    <div class="btn-group dropup" uib-dropdown dropdown-append-to-body>
+      <button id="simple-btn-dropup-append-to-body" type="button" class="btn btn-primary" uib-dropdown-toggle ng-disabled="disabled">
+        Button dropup <span class="caret"></span>
+      </button>
+      <ul class="dropdown-menu" uib-dropdown-menu role="menu" aria-labelledby="simple-btn-dropup-append-to-body">
+        <li role="menuitem"><a href="#">Action</a></li>
+        <li role="menuitem"><a href="#">Another action</a></li>
+        <li role="menuitem"><a href="#">Something else here</a></li>
+        <li class="divider"></li>
+        <li role="menuitem"><a href="#">Separated link</a></li>
+      </ul>
+    </div>
+    <div class="btn-group" uib-dropdown dropdown-append-to-body dropdown-append-to-body>
+      <button id="simple-btn-menu-right-append-to-body" type="button" class="btn btn-primary" uib-dropdown-toggle ng-disabled="disabled">
+        Button dropdown-menu-right <span class="caret"></span>
+      </button>
+      <ul class="dropdown-menu dropdown-menu-right" uib-dropdown-menu role="menu" aria-labelledby="simple-btn-menu-right-append-to-body">
+        <li role="menuitem"><a href="#">Action</a></li>
+        <li role="menuitem"><a href="#">Another action</a></li>
+        <li role="menuitem"><a href="#">Something else here</a></li>
+        <li class="divider"></li>
+        <li role="menuitem"><a href="#">Separated link</a></li>
+      </ul>
+    </div>
+    <div class="btn-group" uib-dropdown dropdown-append-to-body dropdown-placement="top-left">
+      <button id="simple-btn-top-left-append-to-body" type="button" class="btn btn-primary" uib-dropdown-toggle ng-disabled="disabled">
+        Button top-left <span class="caret"></span>
+      </button>
+      <ul class="dropdown-menu" uib-dropdown-menu role="menu" aria-labelledby="simple-btn-top-left-append-to-body">
+        <li role="menuitem"><a href="#">Action</a></li>
+        <li role="menuitem"><a href="#">Another action</a></li>
+        <li role="menuitem"><a href="#">Something else here</a></li>
+        <li class="divider"></li>
+        <li role="menuitem"><a href="#">Separated link</a></li>
+      </ul>
+    </div>
+    <div class="btn-group" uib-dropdown dropdown-append-to-body dropdown-placement="bottom-right">
+      <button id="simple-btn-bottom-right-append-to-body" type="button" class="btn btn-primary" uib-dropdown-toggle ng-disabled="disabled">
+        Button bottom-right <span class="caret"></span>
+      </button>
+      <ul class="dropdown-menu" uib-dropdown-menu role="menu" aria-labelledby="simple-btn-bottom-right-append-to-body">
+        <li role="menuitem"><a href="#">Action</a></li>
+        <li role="menuitem"><a href="#">Another action</a></li>
+        <li role="menuitem"><a href="#">Something else here</a></li>
+        <li class="divider"></li>
+        <li role="menuitem"><a href="#">Separated link</a></li>
+      </ul>
+    </div>
+    <div class="btn-group" uib-dropdown dropdown-append-to-body dropdown-placement="right-top">
+      <button id="simple-btn-right-top-append-to-body" type="button" class="btn btn-primary" uib-dropdown-toggle ng-disabled="disabled">
+        Button right-top <span class="caret"></span>
+      </button>
+      <ul class="dropdown-menu" uib-dropdown-menu role="menu" aria-labelledby="simple-btn-right-top-append-to-body">
+        <li role="menuitem"><a href="#">Action</a></li>
+        <li role="menuitem"><a href="#">Another action</a></li>
+        <li role="menuitem"><a href="#">Something else here</a></li>
+        <li class="divider"></li>
+        <li role="menuitem"><a href="#">Separated link</a></li>
+      </ul>
+    </div>
 
     <script type="text/ng-template" id="dropdown.html">
         <ul class="dropdown-menu" uib-dropdown-menu role="menu" aria-labelledby="button-template-url">

--- a/src/dropdown/docs/readme.md
+++ b/src/dropdown/docs/readme.md
@@ -42,6 +42,25 @@ Each of these parts need to be used as attribute directives.
   <small class="badge">$</small> -
   An optional expression called when the dropdown menu is opened or closed.
 
+* `dropdown-placement`
+  <small class="badge">C</small>
+  _(Default: `auto bottom-left`, Config: `placement`)_ -
+  If specified, bootstrap's dropup and dropdown-menu-right classes will be ignored. Passing in 'auto' separated by a space before the placement will enable auto positioning, e.g: "auto bottom-left". The dropdown will attempt to position the menu where it fits in the closest scrollable ancestor. Accepts:
+
+   * `top` - menu on top, horizontally centered on host element.
+   * `top-left` - menu on top, left edge aligned with host element left edge.
+   * `top-right` - menu on top, right edge aligned with host element right edge.
+   * `bottom` - menu on bottom, horizontally centered on host element.
+   * `bottom-left` - menu on bottom, left edge aligned with host element left edge.
+   * `bottom-right` - menu on bottom, right edge aligned with host element right edge.
+   * `left` - menu on left, vertically centered on host element.
+   * `left-top` - menu on left, top edge aligned with host element top edge.
+   * `left-bottom` - menu on left, bottom edge aligned with host element bottom edge.
+   * `right` - menu on right, vertically centered on host element.
+   * `right-top` - menu on right, top edge aligned with host element top edge.
+   * `right-bottom` - menu on right, bottom edge aligned with host element bottom edge.
+
+
 ### uib-dropdown-menu settings
 
 * `template-url`

--- a/src/position/position.js
+++ b/src/position/position.js
@@ -65,7 +65,7 @@ angular.module('ui.bootstrap.position', [])
       offsetParent: function(elem) {
         elem = this.getRawNode(elem);
 
-        var offsetParent = elem.offsetParent || $document[0].documentElement;
+        var offsetParent = elem;
 
         function isStaticPositioned(el) {
           return ($window.getComputedStyle(el).position || 'static') === 'static';


### PR DESCRIPTION
Add an optional dropdown-placement attribute setting much like the
tooltips'. If it is specified then bootstrap's dropup and
dropdown-menu-right classes will be ignored. Updated positioning of the
dropdown menu to always use the position service. Ensured that dropup
and dropdown-menu-right will be respected for append-to and
append-to-body dropdowns. Updated positioning service to return the
element when looking for the offsetParent if the element is not
statically positioned.

# PLEASE READ

As per the [README](https://github.com/angular-ui/bootstrap/blob/master/README.md), this project is no longer being maintained.  Any PRs entered will not be reviewed or merged and will remain open.

We thank you for your contributions over the years.  This library would not have been successful without them.
